### PR TITLE
Support nil for *sql.DB

### DIFF
--- a/db/checker.go
+++ b/db/checker.go
@@ -44,6 +44,11 @@ func (c Checker) Check() health.Health {
 
 	health := health.NewHealth()
 
+	if c.DB == nil {
+		health.Down().AddInfo("error", "Empty resource")
+		return health
+	}
+
 	err := c.DB.QueryRow(c.CheckSQL).Scan(&ok)
 
 	if err != nil {

--- a/db/checker_test.go
+++ b/db/checker_test.go
@@ -160,3 +160,21 @@ func TestCheck_down_version(t *testing.T) {
 		t.Errorf("message == %s, wants %s", message, expectedError)
 	}
 }
+
+func TestCheck_down_nil_db(t *testing.T) {
+	checker := NewChecker("SELECT 1", "SELECT VERSION()", nil)
+
+	expectedError := "Empty resource"
+
+	health := checker.Check()
+
+	if health.IsUp() {
+		t.Errorf("health.IsUp() == %t, wants %t", health.IsUp(), false)
+	}
+
+	message := health.GetInfo("error")
+
+	if message != expectedError {
+		t.Errorf("message == %s, wants %s", message, expectedError)
+	}
+}


### PR DESCRIPTION
Useful for wrappers if it can return nil:

`health.AddChecker("DB", db.NewPostgreSQLChecker(wrapper.DB()))`